### PR TITLE
Removed postinstall script as it seems to be stopping the package from installing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "dist/index.js",
   "repository": "https://github.com/kindoflew/svelte-parallax",
   "scripts": {
-    "postinstall": "cd ./demo && npm install",
     "dev": "cd ./demo && npm run dev",
     "cy:run": "cypress run",
     "cy:open": "cypress open",


### PR DESCRIPTION
npm ERR! svelte-parallax@0.3.0 postinstall: `cd ./demo && npm install`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the svelte-parallax@0.3.0 postinstall script.
