### PR TITLE
Support rest props

### DIFF
--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -25,8 +25,6 @@
   export let onProgress = undefined;
   /** disable parallax effect, layers will be frozen at target position */
   export let disabled = false;
-  /** style attribute for container. don't forget your semi-colons! */
-  export let style = "";
 
   /** DEPRECATED: use `threshold.top` */
   export let onEnter = undefined;
@@ -124,7 +122,7 @@
     }
 
     svelteScrollTo({
-      y: scrollTarget, 
+      y: scrollTarget,
       duration,
       easing,
       onDone: selector ? focusTarget : () => {}
@@ -134,14 +132,14 @@
 
 <svelte:window
   bind:scrollY={$y}
-  bind:innerHeight={innerHeight}
+  bind:innerHeight
   on:resize={() => setTimeout(setDimensions, 0)}
 />
 
 <div
-  class="parallax-container"
+  {...$$restProps}
+  class="parallax-container {$$restProps.class ? $$restProps.class : ''}"
   bind:this={container}
-  style="{style}"
 >
   <slot />
 </div>

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -57,11 +57,11 @@
   {...$$restProps}
   class="parallax-layer {$$restProps.class ? $$restProps.class : ''}"
   style="
-      {$$restProps.style ? $$restProps.style : ''};
       height: {height}px;
-      -ms-transform: {translate}
-      -webkit-transform: {translate}
-      transform: {translate}
+      -ms-transform: {translate};
+      -webkit-transform: {translate};
+      transform: {translate};
+      {$$restProps.style ? $$restProps.style : ''};
     "
 >
   <slot />

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -9,8 +9,6 @@
   export let offset = 0;
   /** how many sections the layer spans */
   export let span = 1;
-  /** style attribute for layer. don't forget your semi-colons! */
-  export let style = "";
 
   // get context from Parallax
   let {
@@ -24,14 +22,14 @@
   // layer height
   let height;
 
-  const layer = { 
+  const layer = {
     setPosition: (scrollTop, innerHeight, disabled) => {
       // amount to scroll before layer is at target position
       const targetScroll = Math.floor(offset) * innerHeight;
       // distance to target position
       const distance = offset * innerHeight + targetScroll * rate;
-      const current = disabled 
-        ? offset * innerHeight 
+      const current = disabled
+        ? offset * innerHeight
         : -(scrollTop * rate) + distance;
 
       coord.set(current, { hard: disabled });
@@ -56,9 +54,10 @@
 </script>
 
 <div
-  class="parallax-layer"
+  {...$$restProps}
+  class="parallax-layer {$$restProps.class ? $$restProps.class : ''}"
   style="
-      {style}
+      {$$restProps.style ? $$restProps.style : ''};
       height: {height}px;
       -ms-transform: {translate}
       -webkit-transform: {translate}


### PR DESCRIPTION
Since we're creating a `<div>` for each of the components, it's handy to be able to pass arbitrary props to the underlying element.

Also adds a semi-colon to the `style` tag, since `style=";;;width:100%;"` is valid CSS.