### PR TITLE
Remove opinionated styles

### DIFF
--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -148,12 +148,7 @@
 
 <style>
   .parallax-container {
-    width: 100%;
-    position: relative;
     overflow: hidden;
-    -ms-transform: translate3d(0, 0, 0);
-    -webkit-transform: translate3d(0, 0, 0);
-    transform: translate3d(0, 0, 0);
     box-sizing: border-box;
   }
 </style>


### PR DESCRIPTION
This aren't needed for the functionality and can interfere with layouts. The user can add style rules with the `style` tag if needed.