### PR TITLE
Style fixes

### DIFF
--- a/demo/src/BasicDemo.svelte
+++ b/demo/src/BasicDemo.svelte
@@ -26,7 +26,7 @@
     <ParallaxLayer
       rate={(index + 1) / (fancy.length - 1)}
       offset={1}
-      style="margin-left: {38 +
+      style="padding-left: {38 +
         index *
           5}%; display: flex; justify-content: flex-start; align-items: center;"
     >

--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -103,9 +103,8 @@
 
   function setDimensions() {
     // set height here for edge case with more than one Parallax on page
-    $height = sectionHeight ? sectionHeight : innerHeight;
-    container.style.height = `${$height * sections}px`;
-    $top = container.getBoundingClientRect().top + window.pageYOffset;
+    height.set(sectionHeight ? sectionHeight : innerHeight);
+    top.set(container.getBoundingClientRect().top + window.pageYOffset);
   }
 
   export function scrollTo(section, { selector = '', duration = 500, easing = quadInOut } = {}) {
@@ -139,6 +138,10 @@
 <div
   {...$$restProps}
   class="parallax-container {$$restProps.class ? $$restProps.class : ''}"
+  style="
+      height: {$height * sections}px;
+      {$$restProps.style ? $$restProps.style : ''};
+    "
   bind:this={container}
 >
   <slot />


### PR DESCRIPTION
- Fixes margin vs padding in Basic Demo
- The `height` and `top` writable stores need to be assigned with `.set()`
- Sets the style in the markup instead of the JS so it doesn't get overwritten