### PR TITLE
Add transform back

### DIFF
--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -148,6 +148,7 @@
 <style>
   .parallax-container {
     position: relative;
+    transform: translate3d(0, 0, 0);
     overflow: hidden;
     box-sizing: border-box;
   }


### PR DESCRIPTION
Looks like that is a requirement for using `overflow: hidden` when children elements use `transform`. Added back, the demos work correctly now.