### PR TITLE
[FEATURE]: implement ParallaxLayer onProgress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## main (unreleased)
+* [FEATURE]: add `onProgress` prop to `ParallaxLayer`
 
 ## 0.5.2
 * [BUGFIX]: correct type for `selector` in `scrollTo` function

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `<Parallax>` component is a container whose height will be the number of `se
 | ---------------- | ---------------------------------------------------------- | ------------------------------------- |
 | `sections`       | `number`                                                   | `1`                                   |
 | `sectionHeight`  | `number`                                                   | `window.innerHeight`                  |
-| `config`         | `{ stiffness?: number, damping?: number, hard?: boolean }` | `{ stiffness: 0.017, damping: 0.26 }` |
+| `config`         | <pre>{<br/> stiffness?: number;<br/> damping?: number;<br/> hard?: boolean;<br/>}</pre> | `{ stiffness: 0.017, damping: 0.26 }` |
 | `threshold`      | `{ top: number, bottom: number }`                          | `{ top: 1, bottom: 1 }`               |
 | `onProgress`     | `(progress: Progress) => void` (see below)                 | `undefined`                           |
 | `disabled`       | `boolean`                                                  | `false`                               |
@@ -125,7 +125,6 @@ The `<Parallax>` component is a container whose height will be the number of `se
   Currently in section {currentSection}!
 </div>
 <Parallax sections={3} onProgress={handleProgress}>
-  <ParallaxLayer offset={1} style={`transform: rotate(${rotate})`} />
   ...
 </Parallax>
 ```
@@ -192,7 +191,7 @@ Rather than have a click listener on an entire `<ParallaxLayer>` (which I think 
 | Parameters          | Type                                                                    | Description                     |
 | ------------------- | ----------------------------------------------------------------------- | ------------------------------- |
 | `section`           | `number`                                                                | The section to scroll to        |
-| `config` (optional) | `{ selector?: string, duration?: number, easing?: (number) => number }` | Scroll animation config options |  
+| `config` (optional) | <pre>{<br/>&nbsp;&nbsp;selector?: string;<br/>&nbsp;&nbsp;duration?: number;<br/>&nbsp;&nbsp;easing?: (number) => number;<br/>}</pre> | See below |  
 
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Rather than have a click listener on an entire `<ParallaxLayer>` (which I think 
 | Parameters          | Type                                                                    | Description                     |
 | ------------------- | ----------------------------------------------------------------------- | ------------------------------- |
 | `section`           | `number`                                                                | The section to scroll to        |
-| `config` (optional) | <pre>{<br/>&nbsp;&nbsp;selector?: string;<br/>&nbsp;&nbsp;duration?: number;<br/>&nbsp;&nbsp;easing?: (number) => number;<br/>}</pre> | See below |  
+| `config` (optional) | <pre>{<br/> selector?: string;<br/> duration?: number;<br/> easing?: (number) => number;<br/>}</pre> | See below |  
 
 
 <br/>

--- a/cypress/integration/parallax.spec.js
+++ b/cypress/integration/parallax.spec.js
@@ -29,18 +29,22 @@ describe("Parallax", () => {
   });
 
   it("should call onProgress with expected values", () => {
-    cy.get('.progress-details').should('contain', '0 1 0');
+    cy.get('.parallax-progress-details').should('contain', '0 1 0');
+    cy.get('.layer-progress-details').should('contain', '0');
 
     cy.scrollTo(0, HEIGHT / 2);
 
-    cy.get('.progress-details').should('contain', '0.25 1 0.5');
+    cy.get('.parallax-progress-details').should('contain', '0.25 1 0.5');
+    cy.get('.layer-progress-details').should('contain', '0');
 
     cy.scrollTo(0, HEIGHT);
 
-    cy.get('.progress-details').should('contain', '0.5 2 0');
+    cy.get('.parallax-progress-details').should('contain', '0.5 2 0');
+    cy.get('.layer-progress-details').should('contain', '0.5');
 
     cy.scrollTo('bottom');
 
-    cy.get('.progress-details').should('contain', '1 3 0');
+    cy.get('.parallax-progress-details').should('contain', '1 3 0');
+    cy.get('.layer-progress-details').should('contain', '1');
   });
 });

--- a/demo/src/BasicDemo.svelte
+++ b/demo/src/BasicDemo.svelte
@@ -7,7 +7,10 @@
   let show = true;
   let fancy = "fancy".split("");
   const handleProgress = (progress) => {
-    console.log(progress.parallaxProgress, progress.section, progress.sectionProgress);
+    // console.log(progress.parallaxProgress, progress.section, progress.sectionProgress);
+  };
+  const handleLayerProgress = (progress) => {
+    // console.log(progress);
   };
   // disabled = !disabled show = !show
 </script>
@@ -26,9 +29,12 @@
     <ParallaxLayer
       rate={(index + 1) / (fancy.length - 1)}
       offset={1}
-      style="padding-left: {38 +
-        index *
-          5}%; display: flex; justify-content: flex-start; align-items: center;"
+      style="
+        padding-left: {38 + index * 5}%;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+      "
     >
       <p class="fancy">
         {char}
@@ -50,6 +56,7 @@
     offset={1}
     rate={2.5}
     style="display: flex; justify-content: flex-start;"
+    onProgress={handleLayerProgress}
   >
     <div
       style="background-color: yellow; opacity: 0.5; width: 50%; height: 100%;"

--- a/demo/src/BasicDemo.svelte
+++ b/demo/src/BasicDemo.svelte
@@ -64,7 +64,7 @@
   </ParallaxLayer>
 {#if show}
   <ParallaxLayer
-    rate="1"
+    rate={1}
     style="background-color: pink; display: flex; justify-content: center; align-items: center; flex-direction: column;"
   >
     <h1>svelte-parallax!</h1>
@@ -78,8 +78,8 @@
   </ParallaxLayer>
 {/if}
   <ParallaxLayer
-    offset="2"
-    rate="2"
+    offset={2}
+    rate={2}
     style="background-color: pink; display: flex; justify-content: center; align-items: center;"
   >
     <button

--- a/demo/src/TestDemo.svelte
+++ b/demo/src/TestDemo.svelte
@@ -9,15 +9,29 @@
   const handleProgress = (progress) => {
     ({ parallaxProgress, section, sectionProgress } = progress);
   };
+  let layerProgress;
+  const handleLayerProgress = (progress) => {
+    layerProgress = progress;
+  };
 </script>
 
 <button on:click={parallax.scrollTo(2)}>Scroll</button>
-<h1 class='progress-details'>
-  {`${parallaxProgress} ${section} ${sectionProgress}`}
+<h1 >
+  <div class='parallax-progress-details'>
+    {`${parallaxProgress} ${section} ${sectionProgress}`}
+  </div>
+  <div class='layer-progress-details'>
+    {layerProgress}
+  </div>
 </h1>
 
 <Parallax sections={3} bind:this={parallax} onProgress={handleProgress}>
-  <ParallaxLayer offset={1} rate={1} style="background-color: lightblue;"/>
+  <ParallaxLayer
+    offset={1}
+    rate={1}
+    onProgress={handleLayerProgress}
+    style="background-color: lightblue;"
+  />
 </Parallax>
 
 <style>

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ declare module 'svelte-parallax' {
     offset?: number;
     /** how many sections the layer spans */
     span?: number;
+    /** a function that recieves a number representing the intersecting progress of a layer */
+    onProgress?: (progress: number) => void;
     // $$restProps
     [key: string]: any;
   }

--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -2,8 +2,7 @@
   import { setContext, onMount } from "svelte";
   import { writable, derived } from "svelte/store";
   import { quadInOut } from "svelte/easing";
-  import { writableSet } from "./utils/writableSet.js";
-  import { contextKey } from "./utils/contextKey.js";
+  import { writableSet, contextKey, clamp } from "./utils";
   import { scrollTo as svelteScrollTo } from "./scroll-fork/svelteScrollTo.js";
   import "focus-options-polyfill";
 
@@ -48,8 +47,7 @@
     const dy = $y - $top;
     const min = 0 - $height + $height * enter;
     const max = $height * sections - $height * exit;
-    // sorry
-    const step = dy < min ? min : dy > max ? max : dy;
+    const step = clamp(dy, min, max);
     set(step);
   });
 
@@ -137,9 +135,9 @@
   {...$$restProps}
   class="parallax-container {$$restProps.class ? $$restProps.class : ''}"
   style="
-      height: {$height * sections}px;
-      {$$restProps.style ? $$restProps.style : ''};
-    "
+    height: {$height * sections}px;
+    {$$restProps.style ? $$restProps.style : ''};
+  "
   bind:this={container}
 >
   <slot />

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -1,8 +1,7 @@
 <script>
   import { getContext, onMount } from "svelte";
   import { spring } from "svelte/motion";
-  import { contextKey } from "./utils/contextKey.js";
-  import { clamp } from "./utils/clamp.js";
+  import { contextKey, clamp } from "./utils";
 
   /** rate that the layer scrolls relative to `scrollY` */
   export let rate = 0.5;

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -22,7 +22,7 @@
   // spring store to hold changing scroll coordinate
   const coord = spring(undefined, config);
   // and one to hold intersecting progress
-  const progress = spring(0, config);
+  const progress = spring(undefined, config);
   // layer height
   let height;
 
@@ -70,7 +70,7 @@
 
   // translate layer according to coordinate
   $: translate = `translate3d(0px, ${$coord}px, 0px);`;
-  $: if (onProgress) onProgress($progress);
+  $: if (onProgress) onProgress($progress ?? 0);
 </script>
 
 <div

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -2,6 +2,7 @@
   import { getContext, onMount } from "svelte";
   import { spring } from "svelte/motion";
   import { contextKey } from "./utils/contextKey.js";
+  import { clamp } from "./utils/clamp.js";
 
   /** rate that the layer scrolls relative to `scrollY` */
   export let rate = 0.5;
@@ -9,9 +10,11 @@
   export let offset = 0;
   /** how many sections the layer spans */
   export let span = 1;
+  /** a function that recieves a number between 0 and 1, representing the progress of the layer */
+  export let onProgress = undefined;
 
   // get context from Parallax
-  let {
+  const {
     config,
     addLayer,
     removeLayer
@@ -19,23 +22,40 @@
 
   // spring store to hold changing scroll coordinate
   const coord = spring(undefined, config);
+  // and one to hold intersecting progress
+  const progress = spring(0, config);
   // layer height
   let height;
 
-  const layer = {
-    setPosition: (scrollTop, innerHeight, disabled) => {
-      // amount to scroll before layer is at target position
-      const targetScroll = Math.floor(offset) * innerHeight;
-      // distance to target position
-      const distance = offset * innerHeight + targetScroll * rate;
-      const current = disabled
-        ? offset * innerHeight
-        : -(scrollTop * rate) + distance;
+  const getProgress = (scrollTop, rate, distance, sectionHeight) => {
+    const apparentRate = rate + 1;
+    const halfWay = distance / apparentRate;
+    const direction = rate >= 0 ? 1 : -1;
+    const scrollDistance = (sectionHeight / apparentRate) * direction;
+    const start = halfWay - scrollDistance;
+    const end = halfWay + (scrollDistance * span);
+    const progress = (scrollTop - start) / (end - start);
+    return clamp(progress, 0, 1);
+  };
 
-      coord.set(current, { hard: disabled });
+  const layer = {
+    setPosition: (scrollTop, sectionHeight, disabled) => {
+      if (disabled) {
+        coord.set(offset * sectionHeight, { hard: true });
+        return;
+      }
+      // amount to scroll before layer is at target position
+      const targetScroll = Math.floor(offset) * sectionHeight;
+      // distance to target position
+      const distance = offset * sectionHeight + targetScroll * rate;
+      coord.set(-(scrollTop * rate) + distance);
+
+      if (onProgress) {
+        $progress = getProgress(scrollTop, rate, distance, sectionHeight);
+      }
     },
-    setHeight: (innerHeight) => {
-      height = span * innerHeight;
+    setHeight: (sectionHeight) => {
+      height = span * sectionHeight;
     }
   };
 
@@ -51,18 +71,19 @@
 
   // translate layer according to coordinate
   $: translate = `translate3d(0px, ${$coord}px, 0px);`;
+  $: if (onProgress) onProgress($progress);
 </script>
 
 <div
   {...$$restProps}
   class="parallax-layer {$$restProps.class ? $$restProps.class : ''}"
   style="
-      height: {height}px;
-      -ms-transform: {translate};
-      -webkit-transform: {translate};
-      transform: {translate};
-      {$$restProps.style ? $$restProps.style : ''};
-    "
+    height: {height}px;
+    -ms-transform: {translate};
+    -webkit-transform: {translate};
+    transform: {translate};
+    {$$restProps.style ? $$restProps.style : ''};
+  "
 >
   <slot />
 </div>

--- a/src/utils/clamp.js
+++ b/src/utils/clamp.js
@@ -1,0 +1,3 @@
+export const clamp = (val, min, max) => {
+  return val < min ? min : val > max ? max : val;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,3 @@
+export * from './writableSet';
+export * from './contextKey';
+export * from './clamp';


### PR DESCRIPTION
After considering #19 for awhile, decided that `ParallaxLayer` needed its own `onProgress` prop. 

Instead of an object with several values, this function just receives a number between 0 and 1 which represents its "intersecting progress" (for lack of a better term) while scrolling. Starts at `0` when the layer enters the viewport and ends at `1` when it exits the viewport. This way, a user can do cool stuff to the elements inside a `ParallaxLayer` as it passes through the viewport.

Special shoutout to @mateusdeap for talking me through math I probably should have learned by now 😂 