### PR TITLE
[FEATURE]: implement onScroll and update onProgress params

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "svelteSortOrder": "scripts-markup-styles",
   "svelteBracketNewLine": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 100
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * [FEATURE]: add `onProgress` prop to `ParallaxLayer`
 * [FEATURE]: add `StickyLayer` component
 * [FEATURE]: add `let:progress` directive to `ParallaxLayer` as an alternative to using `onProgress` prop
+* [FEATURE]: add `onScroll` prop to `Parallax`
+* [BREAKING CHANGE]: change the parameters passed to `onProgress` in `Parallax` -- it is now just the percent scrolled (represented as a float between `0` and `1`) to be in line with the other two `onProgress` props in the layer components. It is also now a `spring` store, so it will update in-sync with the parallaxing layers. I removed `sectionProgress` and `section` because they are mostly used as references for `ParallaxLayer` motion. And with the addition of `onProgress` for layers, I didn't see much of a use case for them because their values aren't really relevant to how a layer appears in the viewport (ie, if a `ParallaxLayer` is in the viewport for more than one `section`, the values become less helpful). If users want these values back, we could add them back with something like an `onSectionProgress` prop. You can also get the current section using `onScroll` by doing something like `const section = Math.floor(scrollTop / height) + 1` where `height` is `sectionHeight` (default `window.innerHeight`) multiplied by `sections`.
 
 ## 0.5.2
 * [BUGFIX]: correct type for `selector` in `scrollTo` function

--- a/cypress/integration/parallax.spec.js
+++ b/cypress/integration/parallax.spec.js
@@ -44,7 +44,7 @@ describe('Parallax', () => {
   });
 
   it('onProgress and let:progress should have expected values', () => {
-    cy.get('.parallax-progress-details').should('contain', '0 1 0');
+    cy.get('.parallax-progress-details').should('contain', '0');
     cy.get('.layer-progress-details').should('contain', '0');
     cy.get('.layer-let-progress').should('contain', '0');
     cy.get('.sticky-progress-details').should('contain', '0');
@@ -52,7 +52,7 @@ describe('Parallax', () => {
 
     cy.scrollTo(0, HEIGHT / 2);
 
-    cy.get('.parallax-progress-details').should('contain', '0.25 1 0.5');
+    cy.get('.parallax-progress-details').should('contain', '0.25');
     cy.get('.layer-progress-details').should('contain', '0');
     cy.get('.layer-let-progress').should('contain', '0');
     cy.get('.sticky-progress-details').should('contain', '0');
@@ -60,7 +60,7 @@ describe('Parallax', () => {
 
     cy.scrollTo(0, HEIGHT);
 
-    cy.get('.parallax-progress-details').should('contain', '0.5 2 0');
+    cy.get('.parallax-progress-details').should('contain', '0.5');
     cy.get('.layer-progress-details').should('contain', '0.5');
     cy.get('.layer-let-progress').should('contain', '0.5');
     cy.get('.sticky-progress-details').should('contain', '0.5');
@@ -68,7 +68,7 @@ describe('Parallax', () => {
 
     cy.scrollTo('bottom');
 
-    cy.get('.parallax-progress-details').should('contain', '1 3 0');
+    cy.get('.parallax-progress-details').should('contain', '1');
     cy.get('.layer-progress-details').should('contain', '1');
     cy.get('.layer-let-progress').should('contain', '1');
     cy.get('.sticky-progress-details').should('contain', '1');

--- a/demo/src/BasicDemo.svelte
+++ b/demo/src/BasicDemo.svelte
@@ -8,9 +8,9 @@
   let fancy = "fancy".split("");
   const handleScroll = (scrollTop) => {
     // console.log(scrollTop)
-    const sections = 3;
-    const height = window.innerHeight;
-    console.log(Math.floor((scrollTop / height)) + 1);
+    // const sections = 3;
+    // const height = window.innerHeight;
+    // console.log(Math.floor((scrollTop / height)) + 1);
   };
   const handleProgress = (progress) => {
     // console.log(progress);
@@ -23,7 +23,7 @@
 
 <button class="disable" on:click={() => (disabled = !disabled)}>disable</button>
 
-<div style="height:20rem; width: 30rem;"></div>
+<!-- <div style="height:20rem; width: 30rem;"></div> -->
 
 <Parallax
   sections={3} 

--- a/demo/src/BasicDemo.svelte
+++ b/demo/src/BasicDemo.svelte
@@ -6,8 +6,14 @@
   let disabled = false;
   let show = true;
   let fancy = "fancy".split("");
+  const handleScroll = (scrollTop) => {
+    // console.log(scrollTop)
+    const sections = 3;
+    const height = window.innerHeight;
+    console.log(Math.floor((scrollTop / height)) + 1);
+  };
   const handleProgress = (progress) => {
-    // console.log(progress.parallaxProgress, progress.section, progress.sectionProgress);
+    // console.log(progress);
   };
   const handleLayerProgress = (progress) => {
     // console.log(progress);
@@ -17,12 +23,14 @@
 
 <button class="disable" on:click={() => (disabled = !disabled)}>disable</button>
 
-<!-- <div style="height:20rem; width: 30rem;"></div> -->
+<div style="height:20rem; width: 30rem;"></div>
 
-<Parallax 
+<Parallax
   sections={3} 
   style="background-color: #0bdb8c;" 
-  bind:this={parallax} {disabled} 
+  bind:this={parallax}
+  {disabled}
+  onScroll={handleScroll}
   onProgress={handleProgress}
 >
   {#each fancy as char, index (index)}

--- a/demo/src/TestDemo.svelte
+++ b/demo/src/TestDemo.svelte
@@ -9,11 +9,10 @@
 	import StickyLayer from "../../src/StickyLayer.svelte";
 
   let parallax;
+
   let parallaxProgress;
-  let section;
-  let sectionProgress;
   const handleProgress = (progress) => {
-    ({ parallaxProgress, section, sectionProgress } = progress);
+    parallaxProgress = progress;
   };
   let layerProgress;
   const handleLayerProgress = (progress) => {
@@ -28,7 +27,7 @@
 <button on:click={parallax.scrollTo(2)}>Scroll</button>
 <h1 >
   <div class='parallax-progress-details'>
-    {`${parallaxProgress} ${section} ${sectionProgress}`}
+    {parallaxProgress}
   </div>
   <div class='layer-progress-details'>
     {layerProgress}

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,12 +25,6 @@ declare module 'svelte-parallax' {
   }
   export class StickyLayer extends SvelteComponentTyped<StickyLayerProps> {}
 
-  interface Progress {
-    parallaxProgress: number;
-    section: number;
-    sectionProgress: number;
-  }
-
   interface ParallaxProps {
     /** the number of sections the container spans */
     sections?: number;
@@ -46,14 +40,12 @@ declare module 'svelte-parallax' {
       top?: number;
       bottom?: number;
     };
-    /** a function that receives a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
-    onProgress?: (progress: Progress) => void;
+    /** a function that receives a number representing the scroll progress of the container */
+    onProgress?: (progress: number) => void;
+    /** a function that receives "scrollTop" -- the number of pixels scrolled between each threshold */
+    onScroll?: (scrollTop: number) => void;
     /** disable parallax effect, layers will be frozen at target position */
     disabled?: boolean;
-    /** DEPRECATED: use `threshold.top` */
-    onEnter?: boolean;
-    /** DEPRECATED: use `threshold.bottom` */
-    onExit?: boolean;
     // $$restProps
     [key: string]: any;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare module 'svelte-parallax' {
     offset?: number;
     /** how many sections the layer spans */
     span?: number;
-    /** a function that recieves a number representing the intersecting progress of a layer */
+    /** a function that receives a number representing the intersecting progress of a layer */
     onProgress?: (progress: number) => void;
     // $$restProps
     [key: string]: any;
@@ -18,7 +18,7 @@ declare module 'svelte-parallax' {
 	interface StickyLayerProps {
     /** offset bounds where layer is sticky */
     offset?: { top?: number, bottom?: number };
-    /** a function that recieves a number representing the sticky progress of a layer */
+    /** a function that receives a number representing the sticky progress of a layer */
     onProgress?: (progress: number) => void;
     // $$restProps
     [key: string]: any;
@@ -46,7 +46,7 @@ declare module 'svelte-parallax' {
       top?: number;
       bottom?: number;
     };
-    /** a function that recieves a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
+    /** a function that receives a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
     onProgress?: (progress: Progress) => void;
     /** disable parallax effect, layers will be frozen at target position */
     disabled?: boolean;

--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -19,7 +19,7 @@
   export let config = { stiffness: 0.017, damping: 0.26 };
   /** threshold of effect start/end when container enters/exits viewport */
   export let threshold = { top: 1, bottom: 1 };
-  /** a function that recieves a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
+  /** a function that receives a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
   export let onProgress = undefined;
   /** disable parallax effect, layers will be frozen at target position */
   export let disabled = false;

--- a/src/Parallax.svelte
+++ b/src/Parallax.svelte
@@ -1,5 +1,6 @@
 <script>
   import { setContext, onMount } from 'svelte';
+  import { spring } from 'svelte/motion';
   import { writable, derived } from 'svelte/store';
   import { quadInOut } from 'svelte/easing';
   import { writableSet, contextKey, clamp } from './utils';
@@ -19,15 +20,12 @@
   export let config = { stiffness: 0.017, damping: 0.26 };
   /** threshold of effect start/end when container enters/exits viewport */
   export let threshold = { top: 1, bottom: 1 };
-  /** a function that receives a progress object: `{ parallaxProgress: float, section: number, sectionProgress: float }` */
+  /** a function that receives a progress object: `{ progress: float, section: number }` */
   export let onProgress = undefined;
+  /** a function that receives "scrollTop" -- the number of pixels scrolled between each threshold */
+  export let onScroll = undefined;
   /** disable parallax effect, layers will be frozen at target position */
   export let disabled = false;
-
-  /** DEPRECATED: use `threshold.top` */
-  export let onEnter = undefined;
-  /** DEPRECATED: use `threshold.bottom` */
-  export let onExit = undefined;
 
   // bind:scrollY
   const y = writable(0);
@@ -35,44 +33,30 @@
   const top = writable(0);
   // height of a section
   const height = writable(0);
-
-  // this is only here until legacy onEnter/onExit API is removed
-  const legacyEnter = onEnter ? 0 : 1;
-  const legacyExit = onExit ? 0 : 1;
-  const enter = onEnter === undefined ? threshold.top : legacyEnter;
-  const exit = onExit === undefined ? threshold.bottom : legacyExit;
+  // spring store to hold scroll progress
+  const progress = spring(undefined, { ...config, precision: 0.001 });
 
   // fake intersection observer
   const scrollTop = derived([y, top, height], ([$y, $top, $height], set) => {
     const dy = $y - $top;
-    const min = 0 - $height + $height * enter;
-    const max = $height * sections - $height * exit;
+    const min = 0 - $height + $height * threshold.top;
+    const max = $height * sections - $height * threshold.bottom;
     const step = clamp(dy, min, max);
     set(step);
   });
 
-  const getProgress = (scrollTop, height) => {
-    // subtract height because progress doesn't start until top of container is at top of viewport
+  $: if (onScroll) onScroll($scrollTop);
+  $: if (onProgress) setProgress($scrollTop, $height);
+  $: if (onProgress) onProgress($progress ?? 0);
+
+  const setProgress = (scrollTop, height) => {
+    if (height === 0) {
+      progress.set(0);
+      return;
+    }
     const scrollHeight = height * sections - height;
-    const parallaxProgress = scrollTop / scrollHeight;
-    const containerHeight = height * sections;
-    const section = Math.floor((scrollTop / containerHeight) * sections);
-    const sectionScrollTop = scrollTop - height * section;
-    const sectionProgress = sectionScrollTop / height;
-
-    // stop updating parallaxProgress to avoid values greater than 1
-    // stop updating section because we're adding 1 (sections aren't zero-indexed, but the math is)
-    // continue updating sectionProgress in case value is needed beyond the bottom of the container
-    const end = scrollTop >= scrollHeight;
-    onProgress({
-      parallaxProgress: end ? 1 : parallaxProgress,
-      section: end ? sections : section + 1,
-      sectionProgress,
-    });
+    progress.set(clamp(scrollTop / scrollHeight, 0, 1));
   };
-
-  $: if (onProgress && $height > 0 && $scrollTop >= 0)
-    getProgress($scrollTop, $height);
 
   // eventually filled with ParallaxLayer objects
   const layers = writableSet(new Set());
@@ -99,15 +83,12 @@
     setDimensions();
   });
 
-  function setDimensions() {
+  const setDimensions = () => {
     height.set(sectionHeight ? sectionHeight : innerHeight);
     top.set(container.getBoundingClientRect().top + window.pageYOffset);
   }
 
-  export function scrollTo(
-    section,
-    { selector = '', duration = 500, easing = quadInOut } = {}
-  ) {
+  export function scrollTo(section, { selector = '', duration = 500, easing = quadInOut } = {}) {
     const scrollTarget = $top + $height * (section - 1);
 
     const focusTarget = () => {

--- a/src/ParallaxLayer.svelte
+++ b/src/ParallaxLayer.svelte
@@ -9,7 +9,7 @@
   export let offset = 0;
   /** how many sections the layer spans */
   export let span = 1;
-  /** a function that recieves a number between 0 and 1, representing the progress of the layer */
+  /** a function that receives a number between 0 and 1, representing the progress of the layer */
   export let onProgress = undefined;
 
   // get context from Parallax


### PR DESCRIPTION
This PR implements the `onScroll` prop to give users access to `scrollTop` (the number of pixels scrolled while the parallax effect is active) and updates `onProgress` to only use one value -- a float between `0` and `1` that represents the scroll progress of the `Parallax` container.